### PR TITLE
GPU列挙とタブタイトル処理の耐障害性を高めました。 - `wezterm/config.lua:7-25` `wezterm.gui` の存在を確認してからGPUを列挙し、取得できた場合のみ `webgpu_preferred_adapter` を設定するように変更し、GUIのない実行環境でも初期化が失敗しないようにしました。 - `wezterm/events.lua:36-55` タブタイトル生成時に `foreground_process_name` や CWD が得られないケースを考慮し、フォールバック文字列を用意した上で安全に `truncate_right` へ渡すようにしました。 - `wezterm/utils.lua:14-65,82-84` 文字列ユーティリティに型チェックとパス置換時のエスケープを追加し、`nil` など非文字列入力でも例外にならず空文字や元の値を返すようにしました。

### DIFF
--- a/wezterm/config.lua
+++ b/wezterm/config.lua
@@ -4,7 +4,10 @@ local ui = require "./ui"
 local keybinds = require "./keybinds"
 local os = require "./os"
 local events = require "./events"
-local gpus = wezterm.gui.enumerate_gpus()
+local gpus = {}
+if wezterm.gui and wezterm.gui.enumerate_gpus then
+  gpus = wezterm.gui.enumerate_gpus()
+end
 
 -- Register all event handlers
 events.register_events()
@@ -14,10 +17,11 @@ local config = {
   send_composed_key_when_left_alt_is_pressed = true,
   send_composed_key_when_right_alt_is_pressed = true,
   enable_csi_u_key_encoding = false,
-  -- https://github.com/wez/wezterm/issues/2756
-  webgpu_preferred_adapter = gpus[1],
   front_end = "WebGpu",
   scrollback_lines = 5000,
 }
+
+-- https://github.com/wez/wezterm/issues/2756
+if gpus and gpus[1] then config.webgpu_preferred_adapter = gpus[1] end
 
 return utils.object_assign(ui, keybinds, os, config)

--- a/wezterm/events.lua
+++ b/wezterm/events.lua
@@ -33,16 +33,26 @@ function M.format_tab_title(tab, tabs, _, _, hover, max_width)
     trailing_bg = constants.tab_bar.bg
   end
 
-  local title = utils.truncate_right(tab.active_pane.foreground_process_name, max_width)
-  if title == "" then
-    local cwd = tab.active_pane.current_working_dir
-    if type(cwd) == "table" and cwd.file_path then
-      cwd = cwd.file_path
-    elseif type(cwd) ~= "string" then
-      cwd = tostring(cwd)
+  local pane = tab.active_pane
+  local process_name = pane and pane.foreground_process_name or nil
+  local title_source
+
+  if type(process_name) == "string" and process_name ~= "" then
+    title_source = process_name
+  else
+    local cwd = pane and pane.current_working_dir or nil
+    if type(cwd) == "table" then
+      cwd = cwd.file_path or cwd
     end
-    title = utils.truncate_right(utils.convert_home_dir(cwd), max_width)
+    if type(cwd) == "string" and cwd ~= "" then
+      title_source = utils.convert_home_dir(cwd)
+    end
   end
+
+  if type(title_source) ~= "string" or title_source == "" then
+    title_source = "wezterm"
+  end
+  local title = utils.truncate_right(title_source, max_width)
 
   return {
     { Attribute = { Italic = false } },

--- a/wezterm/utils.lua
+++ b/wezterm/utils.lua
@@ -12,10 +12,12 @@ function M.font_with_fallback(name, params)
 end
 
 function M.truncate_right(title, max_width)
+  if type(title) ~= "string" then title = "" end
   return wezterm.truncate_right(M.basename(title), max_width)
 end
 
 function M.basename(s)
+  if type(s) ~= "string" then return "" end
   return string.gsub(s, "(.*[/\\])(.*)", "%2")
 end
 
@@ -53,11 +55,14 @@ function M.exists(tab, element)
 end
 
 function M.convert_home_dir(path)
-  local cwd = path
+  if type(path) ~= "string" then return path end
   local home = os.getenv "HOME"
-  cwd = cwd:gsub("^" .. home .. "/", "~/")
-  if cwd == "" then return path end
-  return cwd
+  if type(home) == "string" and home ~= "" then
+    local escaped_home = home:gsub("(%W)", "%%%1")
+    local converted = path:gsub("^" .. escaped_home .. "/", "~/")
+    if converted ~= "" then return converted end
+  end
+  return path
 end
 
 function M.file_exists(fname)
@@ -75,6 +80,7 @@ function M.convert_useful_path(dir)
 end
 
 function M.split_from_url(dir)
+  if type(dir) ~= "string" then return "", "" end
   local cwd = ""
   local hostname = ""
   local cwd_uri = dir:sub(8)


### PR DESCRIPTION
確認: WezTerm用の自動テストが存在しないため、今回は実行していません。`wezterm start` や `wezterm ls` を手元で試して期待通り動作するか確認してみてください。
