### PR TITLE
fix(zsh): correct tool loader deferral

### DIFF
--- a/zsh/config/loaders/tools.zsh
+++ b/zsh/config/loaders/tools.zsh
@@ -3,20 +3,23 @@
 
 load_tool_settings() {
   local config_dir="$1"
+  local -a critical_tools=(fzf git mise starship)
+  local -A is_critical
+  local has_zsh_defer=$(( $+functions[zsh-defer] ))
 
   # Critical tools - immediate load (minimal set)
-  for critical_tool in fzf git mise starship; do
-    [[ -f "$config_dir/tools/$critical_tool.zsh" ]] &&
-      source "$config_dir/tools/$critical_tool.zsh"
+  for critical_tool in $critical_tools; do
+    is_critical[$critical_tool]=1
+    [[ -f "$config_dir/tools/$critical_tool.zsh" ]] && source "$config_dir/tools/$critical_tool.zsh"
   done
 
   # Non-critical tools - ultra-deferred load with optimized timing
-  for tool_file in "$config_dir/tools"/*.zsh; do
-    local tool_name=$(basename "$tool_file" .zsh)
+  for tool_file in "$config_dir/tools"/*.zsh(N); do
+    local tool_name="${tool_file:t:r}"
     # Skip already loaded critical tools
-    [[ "$tool_name" == "fzf" || "$tool_name" == "git" || "$tool_name" == "mise" ]] && continue
+    (( is_critical[$tool_name] )) && continue
 
-    if (($ + functions[zsh - defer])); then
+    if (( has_zsh_defer )); then
       # Optimized staggered loading for minimal startup impact
       case "$tool_name" in
       brew) zsh-defer -t 3 source "$tool_file" ;;   # Load after mise for proper priority


### PR DESCRIPTION
## 概要
- ツールローダーでzsh-deferの有無を正しく検知して遅延ロードに利用
- クリティカルツールの重複読み込みを防ぎつつ遅延ロードを整理

## 変更内容
- zsh-deferの存在を一度だけ判定するローカルフラグを追加
- クリティカルツールを配列/連想配列で管理し非クリティカルロードから除外
- グロブ展開漏れを防ぐために(N)修飾子で存在しないファイルをスキップ

## 動作確認
- [x] mise run format:prettier
- [x] mise run ci
