### PR TITLE
refactor(nvim): unify autoformat controls

### DIFF
--- a/nvim/lua/config/conform.lua
+++ b/nvim/lua/config/conform.lua
@@ -1,5 +1,6 @@
 -- Conform.nvim configuration for lightweight formatting
 local utils = require "core.utils"
+local autoformat = require "lsp.autoformat"
 local lsp_config = require "lsp.config"
 local util = require "conform.util"
 
@@ -36,8 +37,8 @@ require("conform").setup {
 
   -- Formatter selection strategy
   format_on_save = function(bufnr)
-    -- Disable with a global or buffer-local variable
-    if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then return end
+    -- Respect centralized autoformat flags
+    if not autoformat.is_enabled(bufnr) then return end
 
     return {
       timeout_ms = 3000,
@@ -84,27 +85,6 @@ require("conform").setup {
   log_level = vim.log.levels.WARN,
   notify_on_error = true,
 }
-
--- Auto-format disable/enable commands
-vim.api.nvim_create_user_command("AutoFormatDisable", function(args)
-  if args.bang then
-    -- AutoFormatDisable! will disable formatting globally
-    vim.g.disable_autoformat = true
-  else
-    -- AutoFormatDisable will disable formatting for current buffer
-    vim.b.disable_autoformat = true
-  end
-end, {
-  desc = "Disable autoformat on save",
-  bang = true,
-})
-
-vim.api.nvim_create_user_command("AutoFormatEnable", function()
-  vim.b.disable_autoformat = false
-  vim.g.disable_autoformat = false
-end, {
-  desc = "Re-enable autoformat on save",
-})
 
 -- Status function for debugging
 local function get_format_status()

--- a/nvim/lua/lsp/autoformat.lua
+++ b/nvim/lua/lsp/autoformat.lua
@@ -1,33 +1,54 @@
 -- 自動フォーマットの状態を管理するグローバル変数
 local utils = require "core.utils"
 local config = require "lsp.config"
+local state_keys = config.format.state
 
-vim.g[config.format.state.global] = false
+local function is_global_disabled()
+  return vim.g[state_keys.global] == true
+end
 
--- 自動フォーマットの状態を設定する関数
-local function set_autoformat_state(scope, state)
-  if type(state) ~= "boolean" then return end
+local function is_buffer_disabled(bufnr)
+  return vim.b[bufnr or 0][state_keys.buffer] == true
+end
 
+-- 外部から参照できる状態チェック
+local function set_state(scope, disabled)
   if scope == "buffer" then
-    vim.b[config.format.state.global] = state
-  else
-    vim.g[config.format.state.global] = state
+    vim.b[0][state_keys.buffer] = disabled
+    return
   end
+
+  vim.g[state_keys.global] = disabled
+end
+
+local M = {}
+
+function M.is_enabled(bufnr)
+  return not (is_global_disabled() or is_buffer_disabled(bufnr))
+end
+
+function M.state(bufnr)
+  return {
+    global_disabled = is_global_disabled(),
+    buffer_disabled = is_buffer_disabled(bufnr),
+  }
 end
 
 -- 自動フォーマットを無効化するコマンドを登録
 utils.user_command("AutoFormatDisable", function(args)
-  local scope = args.bang and "buffer" or "global"
-  set_autoformat_state(scope, true)
+  local scope = args.bang and "global" or "buffer"
+  set_state(scope, true)
 end, {
-  desc = "自動フォーマットを無効化",
+  desc = "自動フォーマットを無効化（!でグローバル）",
   bang = true,
 })
 
 -- 自動フォーマットを有効化するコマンドを登録
 utils.user_command("AutoFormatEnable", function()
-  set_autoformat_state("buffer", false)
-  set_autoformat_state("global", false)
+  set_state("buffer", false)
+  set_state("global", false)
 end, {
   desc = "自動フォーマットを有効化",
 })
+
+return M

--- a/nvim/lua/lsp/config.lua
+++ b/nvim/lua/lsp/config.lua
@@ -14,8 +14,9 @@ M.format = {
     async = false,
   },
   state = {
-    global = "format_disabled",
-    buffer = "b:format_disabled",
+    -- Single source of truth for autoformat toggles
+    global = "disable_autoformat",
+    buffer = "disable_autoformat",
   },
 }
 

--- a/nvim/lua/lsp/debug.lua
+++ b/nvim/lua/lsp/debug.lua
@@ -210,9 +210,10 @@ function M.check_lsp_status()
   -- Formatter status
   echo_newline()
   echo_header "Formatter Status"
-  local format_config = require("lsp.config").format
-  local global_format_disabled = vim.g[format_config.state.global] == 1
-  local buffer_format_disabled = vim.b[format_config.state.buffer] == 1
+  local autoformat = require "lsp.autoformat"
+  local format_state = autoformat.state(bufnr)
+  local global_format_disabled = format_state.global_disabled
+  local buffer_format_disabled = format_state.buffer_disabled
 
   echo("• Global formatting: ", "Normal")
   echo(global_format_disabled and "✗ OFF" or "✓ ON", global_format_disabled and "DiagnosticError" or "DiagnosticOk")
@@ -258,10 +259,10 @@ function M.check_lsp_status()
   end
 
   -- Format on save status
-  local format_on_save = vim.api.nvim_buf_get_option(bufnr, "formatexpr") ~= ""
+  local format_on_save = not (global_format_disabled or buffer_format_disabled)
   echo_newline()
   echo("• Format on save: ", "Normal")
-  echo(format_on_save and "configured" or "not configured", format_on_save and "DiagnosticWarn" or "Normal")
+  echo(format_on_save and "enabled" or "disabled", format_on_save and "DiagnosticOk" or "DiagnosticWarn")
   echo_newline()
 
   -- Key bindings reminder


### PR DESCRIPTION
## 概要
- 自動フォーマットの有効/無効状態を1か所で管理するように整理
- ConformとLSPフォーマットの二重トリガーを解消し、コマンド定義を簡潔化

## 変更内容
- lsp.autoformatに状態判定とトグルコマンドを集約し、グローバル/バッファの両方に対応
- Conformのformat_on_saveで集約状態を参照し、重複していたAutoFormatコマンドを削除
- lsp.formatterのBufWritePre自動実行を外し、Format系コマンドとデバッグ出力を整理
- lsp.debugのフォーマット状態表示を新しい状態APIに合わせて更新

## 動作確認
- [x] mise run ci
