### PR TITLE
fix(ci): install Lua build deps for mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libreadline-dev libncurses5-dev
+
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:


### PR DESCRIPTION
## Summary
- install readline/ncurses build deps so mise can compile Lua in CI
- keep mise setup succeeding before luacheck steps

## Testing
- mise run ci