### PR TITLE
docs(zsh): add fzf-git widget keybinds

### DIFF
--- a/docs/tools/zsh.md
+++ b/docs/tools/zsh.md
@@ -84,6 +84,9 @@ zsh-quick-check      # PATH + 主要ツールの健全性チェック
 ^g^a        # Git add -p
 ^g^b / ^gs  # ブランチ/ワークツリー切替 (fzf)
 ^g^w / ^gw  # Git worktree 管理
+^g^z        # fzf-git stash picker
+^g^f        # fzf-git file/diff picker
+^g?         # fzf-git キーバインドヘルプ
 ^g^K        # プロセス kill (fzf)
 ```
 


### PR DESCRIPTION
## 概要
- docs/tools/zsh.md のキー一覧に fzf-git 系ショートカット（stash/file/keymap）を追記して実装と同期

## 種別
- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [x] ドキュメント

## 関連Issue
-

## 確認済み
- [x] 動作確認完了（mise run ci）
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
