### PR TITLE
fix: resolve setup symlink root

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,26 @@
 #!/bin/sh
 set -eu
 
-# Resolve repository root (works even when invoked via symlink)
-DOTFILES=$(cd "$(dirname "$0")" && pwd -P)
+resolve_repo_root() {
+    target=$0
+
+    case $target in
+    /*) ;;
+    *) target=$(command -v -- "$target") ;;
+    esac
+
+    while [ -L "$target" ]; do
+        link=$(readlink "$target")
+        case $link in
+        /*) target=$link ;;
+        *) target=$(dirname "$target")/$link ;;
+        esac
+    done
+
+    cd "$(dirname "$target")" && pwd -P
+}
+
+DOTFILES=$(resolve_repo_root)
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}


### PR DESCRIPTION
## 概要
- setup.sh をシンボリックリンク経由で実行してもリポジトリルートを正しく解決するように修正
- 既存のバックアップ付きリンク生成とXDG配下の初期化を維持し、安全に再実行可能なセットアップにする

## 変更内容
- command -v と readlink を用いた resolve_repo_root を追加し、$0 が指すリンクを辿って実体パスから DOTFILES を決定
- 既存のディレクトリ作成やリンク張り替えロジックは変更せず、symlink経由実行時の Missing source を解消

## 動作確認
- [x] mise run ci
- [ ] eslint（設定ファイルなし）
- [ ] prettier（CI内で関連チェック済み）