### PR TITLE
chore: align format/lint tasks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -29,7 +29,7 @@ depends = [
 # 集約タスク（Lintまとめ）
 [tasks.lint]
 description = "全体の品質チェック（GitHub Actions互換）- 並列実行"
-depends = ["lint:biome", "lint:markdown", "lint:yaml", "lint:lua", "lint:shell"]
+depends = ["lint:biome", "lint:markdown", "lint:toml", "lint:yaml", "lint:lua", "lint:shell"]
 
 # 更新タスク（mac/local 依存）
 [tasks.update]

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -225,6 +225,16 @@ run = [
   "fd -e md -X prettier --check",
 ]
 
+[tasks."lint:toml"]
+description = "TOML ファイルをチェック（TOML_FILES で対象を限定可能）"
+run = """
+if [ -n "${TOML_FILES:-}" ]; then
+  taplo format --check ${TOML_FILES}
+else
+  taplo format --check .
+fi
+"""
+
 [tasks."lint:yaml"]
 description = "YAML ファイルをチェック（prettier + yamllint、YAML_FILES で対象を限定可能）"
 run = """
@@ -249,8 +259,14 @@ fi
 """
 
 [tasks."lint:shell"]
-description = "シェルスクリプトをチェック"
-run = "fd -e sh -X shfmt -d"
+description = "シェルスクリプトをチェック（SH_FILES で対象を限定可能）"
+run = """
+if [ -n "${SH_FILES:-}" ]; then
+  shfmt -d -i 2 -ci -bn ${SH_FILES}
+else
+  fd -e sh -X shfmt -d -i 2 -ci -bn
+fi
+"""
 
 [tasks."lint:links"]
 description = "Markdown リンクチェック（時間がかかるため個別実行推奨）"

--- a/setup.sh
+++ b/setup.sh
@@ -2,29 +2,29 @@
 set -eu
 
 resolve_repo_root() {
-    target=$0
+  target=$0
 
-    case $target in
+  case $target in
     /*) ;;
     *) target=$(command -v -- "$target") ;;
+  esac
+
+  while [ -L "$target" ]; do
+    link=$(readlink "$target")
+    case $link in
+      /*) target=$link ;;
+      *) target=$(dirname "$target")/$link ;;
     esac
+  done
 
-    while [ -L "$target" ]; do
-        link=$(readlink "$target")
-        case $link in
-        /*) target=$link ;;
-        *) target=$(dirname "$target")/$link ;;
-        esac
-    done
-
-    cd "$(dirname "$target")" && pwd -P
+  cd "$(dirname "$target")" && pwd -P
 }
 
 DOTFILES=${DOTFILES:-"$(resolve_repo_root)"}
 
 if [ ! -d "$DOTFILES" ]; then
-    echo "Dotfiles directory not found: $DOTFILES" >&2
-    exit 1
+  echo "Dotfiles directory not found: $DOTFILES" >&2
+  exit 1
 fi
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$HOME/.config"}
@@ -33,36 +33,36 @@ XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
 XDG_STATE_HOME=${XDG_STATE_HOME:-"$HOME/.local/state"}
 
 link() {
-    src=$1
-    dest=$2
+  src=$1
+  dest=$2
 
-    if [ ! -e "$src" ]; then
-        printf "Missing source: %s\n" "$src" >&2
-        exit 1
-    fi
+  if [ ! -e "$src" ]; then
+    printf "Missing source: %s\n" "$src" >&2
+    exit 1
+  fi
 
-    if [ -e "$dest" ] && [ ! -L "$dest" ]; then
-        backup="${dest}.bak.$(date +%s)"
-        mv "$dest" "$backup"
-        printf "Backed up %s to %s\n" "$dest" "$backup"
-    fi
+  if [ -e "$dest" ] && [ ! -L "$dest" ]; then
+    backup="${dest}.bak.$(date +%s)"
+    mv "$dest" "$backup"
+    printf "Backed up %s to %s\n" "$dest" "$backup"
+  fi
 
-    mkdir -p "$(dirname "$dest")"
-    ln -sfn "$src" "$dest"
+  mkdir -p "$(dirname "$dest")"
+  ln -sfn "$src" "$dest"
 }
 
 # Base directories (idempotent)
 mkdir -p \
-    "$HOME/tmp" \
-    "$XDG_CONFIG_HOME" \
-    "$XDG_CACHE_HOME" \
-    "$XDG_DATA_HOME" \
-    "$XDG_STATE_HOME" \
-    "$HOME/.local/share/zsh-autocomplete" \
-    "$HOME/.mise" \
-    "$HOME/.ssh/ssh_config.d" \
-    "$HOME/.ssh/sockets" \
-    "$HOME/.awsume"
+  "$HOME/tmp" \
+  "$XDG_CONFIG_HOME" \
+  "$XDG_CACHE_HOME" \
+  "$XDG_DATA_HOME" \
+  "$XDG_STATE_HOME" \
+  "$HOME/.local/share/zsh-autocomplete" \
+  "$HOME/.mise" \
+  "$HOME/.ssh/ssh_config.d" \
+  "$HOME/.ssh/sockets" \
+  "$HOME/.awsume"
 
 # XDG config directories managed by the repo
 CONFIG_DIRS="
@@ -91,7 +91,7 @@ zsh-abbr
 "
 
 for dir in $CONFIG_DIRS; do
-    link "$DOTFILES/$dir" "$XDG_CONFIG_HOME/$dir"
+  link "$DOTFILES/$dir" "$XDG_CONFIG_HOME/$dir"
 done
 
 # File-level configs
@@ -121,7 +121,7 @@ link "$XDG_CONFIG_HOME/ssh/config" "$HOME/.ssh/config"
 chmod 700 "$HOME/.ssh"
 
 if [ -f "$DOTFILES/.gitmodules" ]; then
-    git -C "$DOTFILES" submodule update --init --recursive
+  git -C "$DOTFILES" submodule update --init --recursive
 fi
 
 printf "Dotfiles setup complete. XDG config: %s\n" "$XDG_CONFIG_HOME"


### PR DESCRIPTION
## 概要

- format/lint の集約タスクを揃え、TOML チェックを追加
- shfmt のオプションを lint/format で統一し、setup.sh を再フォーマット
- `mise run ci` で format/lint の抜けがないように調整

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`
