### PR TITLE
chore(ci): shfmt ci-local helper

### DIFF
--- a/.claude/commands/ci-local.sh
+++ b/.claude/commands/ci-local.sh
@@ -17,27 +17,27 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 log_info() {
-    echo -e "${BLUE}ℹ${NC} $1"
+  echo -e "${BLUE}ℹ${NC} $1"
 }
 
 log_success() {
-    echo -e "${GREEN}✅${NC} $1"
+  echo -e "${GREEN}✅${NC} $1"
 }
 
 log_warning() {
-    echo -e "${YELLOW}⚠${NC} $1"
+  echo -e "${YELLOW}⚠${NC} $1"
 }
 
 log_error() {
-    echo -e "${RED}❌${NC} $1"
+  echo -e "${RED}❌${NC} $1"
 }
 
 log_section() {
-    echo -e "${CYAN}━━━ $1 ━━━${NC}"
+  echo -e "${CYAN}━━━ $1 ━━━${NC}"
 }
 
 usage() {
-    cat <<EOF
+  cat <<EOF
 Usage: ci-local [OPTIONS] [COMMAND]
 
 ローカルでGitHub Actions CI (.github/workflows/ci.yml) と同等のチェックを実行
@@ -64,153 +64,153 @@ EOF
 }
 
 check_mise_installation() {
-    if ! command -v mise &>/dev/null; then
-        log_error "mise が見つかりません"
-        log_info "mise をインストールしてください: https://mise.jdx.dev/getting-started.html"
-        exit 1
-    fi
-    log_success "mise が利用可能です"
+  if ! command -v mise &>/dev/null; then
+    log_error "mise が見つかりません"
+    log_info "mise をインストールしてください: https://mise.jdx.dev/getting-started.html"
+    exit 1
+  fi
+  log_success "mise が利用可能です"
 }
 
 setup_environment() {
-    log_section "環境のセットアップ"
+  log_section "環境のセットアップ"
 
-    cd "$PROJECT_ROOT"
+  cd "$PROJECT_ROOT"
 
-    # mise install でツールをインストール
-    log_info "mise を使用して開発ツールをインストール中..."
-    mise install
+  # mise install でツールをインストール
+  log_info "mise を使用して開発ツールをインストール中..."
+  mise install
 
-    # 必要な追加ツールをインストール
-    install_tools
+  # 必要な追加ツールをインストール
+  install_tools
 
-    log_success "環境のセットアップが完了しました"
+  log_success "環境のセットアップが完了しました"
 }
 
 install_tools() {
-    log_section "追加ツールのインストール"
+  log_section "追加ツールのインストール"
 
-    cd "$PROJECT_ROOT"
+  cd "$PROJECT_ROOT"
 
-    # mise run ci:install を実行して必要なツールをインストール
-    log_info "必要なツールをインストール中..."
-    if mise run ci:install; then
-        log_success "ツールのインストールが完了しました"
-    else
-        log_warning "一部のツールのインストールに失敗しましたが、継続します"
-    fi
+  # mise run ci:install を実行して必要なツールをインストール
+  log_info "必要なツールをインストール中..."
+  if mise run ci:install; then
+    log_success "ツールのインストールが完了しました"
+  else
+    log_warning "一部のツールのインストールに失敗しましたが、継続します"
+  fi
 
-    # PATH に LuaRocks bin を追加
-    if [[ -d "$HOME/.luarocks/bin" ]]; then
-        export PATH="$HOME/.luarocks/bin:$PATH"
-        log_info "LuaRocks bin を PATH に追加しました"
-    fi
+  # PATH に LuaRocks bin を追加
+  if [[ -d "$HOME/.luarocks/bin" ]]; then
+    export PATH="$HOME/.luarocks/bin:$PATH"
+    log_info "LuaRocks bin を PATH に追加しました"
+  fi
 }
 
 run_ci_checks() {
-    log_section "CI チェックの実行"
+  log_section "CI チェックの実行"
 
-    cd "$PROJECT_ROOT"
+  cd "$PROJECT_ROOT"
 
-    local failed=0
+  local failed=0
 
-    # 各チェックを順番に実行し、結果を記録
-    local checks=(
-        "format:biome:check|Biome チェック (JS/TS/JSON)"
-        "format:markdown:check|Markdown フォーマット"
-        "format:yaml:check|YAML フォーマット"
-        "lint:lua|Lua lint (luacheck)"
-        "format:lua:check|Lua フォーマット (stylua)"
-        "format:shell:check|Shell フォーマット (shfmt)"
-    )
+  # 各チェックを順番に実行し、結果を記録
+  local checks=(
+    "format:biome:check|Biome チェック (JS/TS/JSON)"
+    "format:markdown:check|Markdown フォーマット"
+    "format:yaml:check|YAML フォーマット"
+    "lint:lua|Lua lint (luacheck)"
+    "format:lua:check|Lua フォーマット (stylua)"
+    "format:shell:check|Shell フォーマット (shfmt)"
+  )
 
-    for check in "${checks[@]}"; do
-        local task="${check%|*}"
-        local name="${check#*|}"
+  for check in "${checks[@]}"; do
+    local task="${check%|*}"
+    local name="${check#*|}"
 
-        log_info "実行中: $name"
-        if mise run "$task"; then
-            log_success "$name - PASSED"
-        else
-            log_error "$name - FAILED"
-            ((failed++))
-        fi
-        echo
-    done
-
-    # 結果のサマリー
-    log_section "チェック結果"
-    local total=${#checks[@]}
-    local passed=$((total - failed))
-
-    if [[ $failed -eq 0 ]]; then
-        log_success "すべてのチェックが成功しました! ($passed/$total)"
-        log_info "GitHub Actions CI も成功するはずです ✨"
-        return 0
+    log_info "実行中: $name"
+    if mise run "$task"; then
+      log_success "$name - PASSED"
     else
-        log_error "$failed/$total のチェックが失敗しました"
-        log_warning "GitHub Actions CI でも失敗する可能性があります"
-        return 1
+      log_error "$name - FAILED"
+      ((failed++))
     fi
+    echo
+  done
+
+  # 結果のサマリー
+  log_section "チェック結果"
+  local total=${#checks[@]}
+  local passed=$((total - failed))
+
+  if [[ $failed -eq 0 ]]; then
+    log_success "すべてのチェックが成功しました! ($passed/$total)"
+    log_info "GitHub Actions CI も成功するはずです ✨"
+    return 0
+  else
+    log_error "$failed/$total のチェックが失敗しました"
+    log_warning "GitHub Actions CI でも失敗する可能性があります"
+    return 1
+  fi
 }
 
 main() {
-    local command="check"
+  local command="check"
 
-    # Parse arguments
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        --no-color)
-            # Disable colors
-            RED=''
-            GREEN=''
-            YELLOW=''
-            BLUE=''
-            CYAN=''
-            NC=''
-            shift
-            ;;
-        --verbose)
-            set -x
-            shift
-            ;;
-        check | install | setup)
-            command="$1"
-            shift
-            ;;
-        *)
-            log_error "不明なオプション: $1"
-            usage
-            exit 1
-            ;;
-        esac
-    done
-
-    check_mise_installation
-
-    case $command in
-    setup)
-        setup_environment
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h | --help)
+        usage
+        exit 0
         ;;
-    install)
-        install_tools
+      --no-color)
+        # Disable colors
+        RED=''
+        GREEN=''
+        YELLOW=''
+        BLUE=''
+        CYAN=''
+        NC=''
+        shift
         ;;
-    check)
-        run_ci_checks
+      --verbose)
+        set -x
+        shift
         ;;
-    *)
-        log_error "不明なコマンド: $command"
+      check | install | setup)
+        command="$1"
+        shift
+        ;;
+      *)
+        log_error "不明なオプション: $1"
         usage
         exit 1
         ;;
     esac
+  done
+
+  check_mise_installation
+
+  case $command in
+    setup)
+      setup_environment
+      ;;
+    install)
+      install_tools
+      ;;
+    check)
+      run_ci_checks
+      ;;
+    *)
+      log_error "不明なコマンド: $command"
+      usage
+      exit 1
+      ;;
+  esac
 }
 
 # スクリプトが直接実行された場合のみ main を呼び出す
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"
+  main "$@"
 fi


### PR DESCRIPTION
## 概要

- `.claude/commands/ci-local.sh` を shfmt で整形し、`mise lint:shell` に沿ったスタイルに統一

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---