### PR TITLE
chore(biome): update schema to 2.3.8

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## 概要

- Biome設定のschemaを2.3.8に更新し、lint:biomeのスキーマ不一致エラーを解消しました
- `mise run lint:biome` と `mise run ci` で確認しています

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`
