### PR TITLE
chore(mise): fix markdown lint glob

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -14,8 +14,8 @@ trusted_config_paths = ["~/src/github.com", "/private/var/folders"]
 [env]
 _.source = [".venv/bin/activate"]
 YAMLLINT_CONFIG_FILE = "yamllint/config"
-MD_GLOB = "'**/*.md'"
-MD_EXCLUDES = "'#node_modules' '#tmux/plugins' '#fisher' '#zsh/.zinit'"
+MD_GLOB = "**/*.md"
+MD_EXCLUDES = "#node_modules #tmux/plugins #fisher #zsh/.zinit"
 
 # ========================================
 # オプション環境変数（ファイル限定処理）


### PR DESCRIPTION
## 概要
- markdownlint の glob/exclude を素の文字列にして lint:markdown が全Markdownを検査するよう調整
- `mise run lint:markdown` と `mise run ci` が通ることを確認

## 種別
- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲
- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue
- なし

## 確認済み
- [x] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---