### PR TITLE
fix(zsh): store history in XDG_STATE_HOME

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -12,6 +12,7 @@ export ZDOTDIR GIT_CONFIG_GLOBAL
 # History file should be set before shell init so history loads
 # even if .zshrc is skipped. Keep it under XDG state by default.
 : "${HISTFILE:=${XDG_STATE_HOME}/zsh/history}"
+export HISTFILE
 
 # Temporary Files
 if [[ ! -d "$TMPDIR" ]]; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -2,11 +2,6 @@
 : "${XDG_STATE_HOME:=${HOME}/.local/state}"
 bindkey -e
 
-# Keep history under XDG state by default; allow HISTFILE override if set.
-: "${HISTFILE:=${XDG_STATE_HOME}/zsh/history}"
-mkdir -p "${HISTFILE:h}"
-HISTSIZE=100000
-SAVEHIST=100000
 setopt append_history
 setopt auto_cd
 setopt auto_menu
@@ -50,4 +45,11 @@ for f in "${ZDOTDIR:-$HOME}"/init/*.zsh; do source "${f}"; done
 
 # Source additional configurations
 for f in "${ZDOTDIR:-$HOME}"/sources/*.zsh; do source "${f}"; done
+
+# Enforce XDG history location after plugins/sources load.
+HISTFILE="${XDG_STATE_HOME}/zsh/history"
+mkdir -p "${HISTFILE:h}"
+export HISTFILE
+HISTSIZE=100000
+SAVEHIST=100000
 # vim: set syntax=zsh:


### PR DESCRIPTION
## 概要

- HISTFILE のデフォルトを XDG_STATE_HOME/zsh/history に固定し、.zshenv にも設定して早期に読み込まれるように調整
- 旧 ~/.zsh_history 系をバックアップ・マージのうえ削除し、XDG 側に一本化（~/.config/zsh/.zsh_history もシンボリックリンク化済み）
- mise run ci でフォーマット/リンク系チェックを実行

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
