### PR TITLE
Fix lint:shell fd search paths for shellcheck

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -47,7 +47,7 @@ if [ -n "${SH_FILES:-}" ]; then
 else
   fd -e sh -X shfmt -d -i 2 -ci -bn
   fd -e sh -X shellcheck
-  fd -e zsh zsh/lazy-sources zsh/sources -X shellcheck
+  fd -e zsh . zsh/lazy-sources zsh/sources -X shellcheck
 fi
 """
 

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -268,7 +268,7 @@ if [ -n "${SH_FILES:-}" ]; then
 else
   fd -e sh -X shfmt -d -i 2 -ci -bn
   fd -e sh -X shellcheck
-  fd -e zsh zsh/lazy-sources zsh/sources -X shellcheck
+  fd -e zsh . zsh/lazy-sources zsh/sources -X shellcheck
 fi
 """
 


### PR DESCRIPTION
## 概要

- fdの検索パス指定を修正し、`lint:shell`がzshファイルを正しくshellcheckできるようにしました
- `.mise.toml`と`mise/config.toml`を同期し、`mise run lint`/`mise run ci`が通ることを確認しました

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`
