### PR TITLE
chore: add .gitattributes for lazy-lock.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Neovim lazy.nvim lock file
+nvim/lazy-lock.json linguist-generated=true diff=none merge=ours


### PR DESCRIPTION
## Summary

- Configure `lazy-lock.json` with `.gitattributes`
  - `linguist-generated=true`: Hide from GitHub language stats
  - `diff=none`: Skip hash diffs in reviews
  - `merge=ours`: Auto-resolve merge conflicts

## Benefits

- Cleaner PR reviews (no plugin hash diffs)
- Automatic conflict resolution on merge
- Cleaner GitHub language statistics