### PR TITLE
chore(gitignore): exclude auto-generated telemetry and external symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,14 @@ fish/
 fisher/
 karabiner/automatic_backups/
 github-copilot/
+
+# Auto-generated telemetry configs
+clerk/
+nextjs-nodejs/
+
+# OpenCode external skill symlinks
+opencode/skills/
+
 op/
 jgit/
 raycast/


### PR DESCRIPTION
## Summary
- `.gitignore`に3つのディレクトリの除外パターンを追加
- 自動生成されるテレメトリデータと外部シンボリックリンクを除外

## Changes
- **clerk/**: Clerkテレメトリ設定（自動生成、個人識別子を含む）
- **nextjs-nodejs/**: Next.jsテレメトリ設定（自動生成、機密性のあるハッシュデータ）
- **opencode/skills/**: `~/.agents/skills/`への外部シンボリックリンク（バージョン管理対象外）

## Test plan
- [x] `git status`で3つのディレクトリが表示されないことを確認
- [x] `git check-ignore -v`でパターンが正しく機能することを確認
- [x] `opencode/opencode.json`が引き続き追跡されていることを確認

## Rationale
- 既存の除外パターン（`configstore/`, `github-copilot/`等）と整合性を保つ
- 自動生成データと外部参照を適切に除外する原則に従う
- 再現可能な設定（追跡）と生成された状態（除外）を分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)