### PR TITLE
fix: correct package name from openclawd to openclaw

### DIFF
--- a/mise/config.default.toml
+++ b/mise/config.default.toml
@@ -138,6 +138,7 @@ yamllint = "latest"
 "npm:@sasazame/ccresume" = "latest"
 "npm:ccusage" = "latest"
 "npm:dev3000" = "latest"
+"npm:openclaw" = "latest"
 
 # クラウド・インフラ
 "npm:aws-cdk" = "latest"

--- a/mise/config.pi.toml
+++ b/mise/config.pi.toml
@@ -97,7 +97,7 @@ yamllint = "latest"
 # Claude/AI ツール
 # 注: デスクトップ開発ツール (dxt, dev3000, ccusage) は除外
 "npm:@sasazame/ccresume" = "latest"
-"npm:openclawd" = "latest"
+"npm:openclaw" = "latest"
 
 # 注: クラウド・インフラツールは除外 (aws-cli で十分)
 


### PR DESCRIPTION
## 概要

mise設定ファイルで誤ったパッケージ名 `openclawd` を正しい `openclaw` に修正しました。

`openclawd` はプレースホルダーパッケージで、タイポを警告するためのものです。正しいパッケージ名は `openclaw` です。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 変更内容

### ファイル

- `mise/config.pi.toml`: `npm:openclawd` を `npm:openclaw` に更新
- `mise/config.default.toml`: Claude/AIツールセクションに `npm:openclaw` を追加

### 詳細

openclaw onboard コマンドが実行できない問題を調査した結果、パッケージ名が間違っていることが判明しました。

- **Before**: `npm:openclawd@1.0.0` (プレースホルダーパッケージ)
- **After**: `npm:openclaw@2026.2.1` (実際のCLIツール)

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [x] 動作確認完了 (`mise exec -- openclaw --version` が成功)
- [x] 品質チェック通過 (設定ファイルの構文が正しい)
- [ ] Terraform変更時: `terraform validate && terraform plan` (該当なし)

---

🤖 Generated with [Claude Code](https://claude.ai/code)