### PR TITLE
feat: add update:apt task for Ubuntu/Debian environments

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -49,7 +49,7 @@ run = "if command -v brew >/dev/null 2>&1; then brew bundle install --no-upgrade
 # ========================================
 [tasks.update]
 description = "すべての依存関係を更新"
-depends = ["update:submodules", "update:brew", "update:external-repos"]
+depends = ["update:submodules", "update:brew", "update:apt", "update:external-repos"]
 
 [tasks."update:submodules"]
 description = "Git サブモジュールを最新に更新（ローカル変更を破棄）"
@@ -58,6 +58,10 @@ run = "if [ -f .gitmodules ]; then git submodule foreach 'git reset --hard HEAD 
 [tasks."update:brew"]
 description = "Homebrew パッケージを更新（formula のみ、cask は除く）"
 run = "if command -v brew >/dev/null 2>&1; then (brew update 2>&1 | grep -v \"definition is invalid\" || true) && brew upgrade --formula; else echo 'Homebrew not installed, skipping brew update'; fi"
+
+[tasks."update:apt"]
+description = "APT パッケージを更新（Ubuntu/Debian 環境）"
+run = "if command -v apt-get >/dev/null 2>&1 && [ -f /etc/debian_version ]; then sudo apt-get update && sudo apt-get upgrade -y; else echo 'APT not available, skipping apt update'; fi"
 
 [tasks."update:external-repos"]
 description = "外部 Git リポジトリを更新（強制リセット）"


### PR DESCRIPTION
## 概要

\`update:brew\`タスクと同様のパターンで、Ubuntu/Debian環境向けに\`update:apt\`タスクを追加しました。

## 変更内容

### 1. \`update:apt\`タスクの追加

\`\`\`toml
[tasks."update:apt"]
description = "APT パッケージを更新（Ubuntu/Debian 環境）"
run = "if command -v apt-get >/dev/null 2>&1 && [ -f /etc/debian_version ]; then sudo apt-get update && sudo apt-get upgrade -y; else echo 'APT not available, skipping apt update'; fi"
\`\`\`

**機能**:
- \`apt-get update\`: パッケージリスト更新
- \`apt-get upgrade -y\`: インストール済みパッケージの更新（自動承認）
- 環境チェック: \`apt-get\`コマンドの存在 + \`/etc/debian_version\`ファイル
- 未対応環境では安全にスキップ

### 2. \`update\`タスクへの統合

\`\`\`toml
[tasks.update]
description = "すべての依存関係を更新"
depends = ["update:submodules", "update:brew", "update:apt", "update:external-repos"]
\`\`\`

実行順序: submodules → brew → apt → external-repos

## 動作環境

### macOS
- ✅ \`update:brew\`: 実行される
- ⏭️ \`update:apt\`: 安全にスキップ

### Ubuntu/Debian (Raspberry Pi含む)
- ⏭️ \`update:brew\`: 安全にスキップ
- ✅ \`update:apt\`: 実行される

## 検証結果

\`\`\`bash
# Raspberry Pi環境での検証
$ mise tasks ls | grep "^update:"
update:apt             APT パッケージを更新（Ubuntu/Debian 環境）
update:brew            Homebrew パッケージを更新（formula のみ、cask は除く）
update:external-repos  外部 Git リポジトリを更新（強制リセット）
update:submodules      Git サブモジュールを最新に更新（ローカル変更を破棄）

$ command -v apt-get && echo "apt-get available"
/usr/bin/apt-get
apt-get available

$ [ -f /etc/debian_version ] && echo "Debian-based"
Debian-based
\`\`\`

## 注意事項

- **sudo権限**: \`apt-get upgrade\`にはsudo権限が必要（パスワードプロンプトが表示される）
- **自動承認**: \`-y\`フラグで更新を自動承認
- **環境依存**: Debian系以外の環境では安全にスキップされる

## テスト方法

\`\`\`bash
# タスク一覧確認
mise tasks ls | grep "^update:"

# 環境確認（ドライラン）
command -v apt-get && echo "apt-get available" || echo "apt-get not available"
[ -f /etc/debian_version ] && echo "Debian-based" || echo "Not Debian-based"

# 統合更新タスク実行
mise run update

# 個別タスク実行
mise run update:apt
\`\`\`