### PR TITLE
chore: exclude worktrees from format/lint

### DIFF
--- a/.fdignore
+++ b/.fdignore
@@ -4,6 +4,9 @@ tmux/plugins/
 fisher/
 zsh/.zinit/
 claude/local/node_modules/
+.worktrees/
+result/
+result-*/
 
 # Imported agent skills (managed separately)
 agents/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ repomix-output.txt
 *.bk
 *.bk.*
 *.backup
+.worktrees/
 result
 result-*
 *.bak

--- a/.ignore
+++ b/.ignore
@@ -1,4 +1,5 @@
 .git
+.worktrees
 .wrangler
 .vim
 raycast/extensions
@@ -7,3 +8,5 @@ tmux/plugins
 .yarn
 opencode
 codex
+result
+result-*

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,9 @@ node_modules/
 tmux/plugins/
 fisher/
 zsh/.zinit/
+.worktrees/
+result/
+result-*/
 codex/AGENTS.md
 opencode/AGENTS.md
 claude/local/node_modules/

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -28,8 +28,8 @@ package_manager = "pnpm"
 _.source = [".venv/bin/activate"]
 YAMLLINT_CONFIG_FILE = "yamllint/config"
 MD_GLOB = "**/*.md"
-MD_EXCLUDES = "#node_modules #tmux/plugins #fisher #zsh/.zinit #agents/skills"
-TASK_EXCLUDES = "--exclude agents/skills"
+MD_EXCLUDES = "#node_modules #tmux/plugins #fisher #zsh/.zinit #agents/skills #.worktrees #result #result-*"
+TASK_EXCLUDES = "--exclude agents/skills --exclude .worktrees --exclude result --exclude result-*"
 
 # ========================================
 # オプション環境変数（ファイル限定処理）

--- a/mise/tasks/format.toml
+++ b/mise/tasks/format.toml
@@ -81,7 +81,7 @@ run = """
 if [ -n "${LUA_FILES:-}" ]; then
   stylua ${LUA_FILES}
 else
-  stylua .
+  fd --hidden -e lua ${TASK_EXCLUDES} -X stylua
 fi
 """
 
@@ -91,7 +91,7 @@ run = """
 if [ -n "${LUA_FILES:-}" ]; then
   stylua --check ${LUA_FILES}
 else
-  stylua --check .
+  fd --hidden -e lua ${TASK_EXCLUDES} -X stylua --check
 fi
 """
 

--- a/mise/tasks/lint.toml
+++ b/mise/tasks/lint.toml
@@ -112,10 +112,18 @@ run = """
 if [ -n "${LUA_FILES:-}" ]; then
   stylua --check ${LUA_FILES}
 else
-  stylua --check .
+  fd --hidden -e lua ${TASK_EXCLUDES} -X stylua --check
 fi
 """
 
 ["lint:lua:luacheck"]
 description = "luacheck を実行（利用可能な場合）"
-run = "if command -v luacheck >/dev/null 2>&1; then luacheck -q .; fi"
+run = """
+if command -v luacheck >/dev/null 2>&1; then
+  if [ -n "${LUA_FILES:-}" ]; then
+    luacheck -q ${LUA_FILES}
+  else
+    fd --hidden -e lua ${TASK_EXCLUDES} -X luacheck -q
+  fi
+fi
+"""


### PR DESCRIPTION
## 概要

- format/lint から `.worktrees` と `result*` を除外
- Lua の format/lint を `fd + TASK_EXCLUDES` に統一

実行:
- `mise run lint:markdown`

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->