### PR TITLE
Align ci-local with GitHub Actions CI workflow checks

### DIFF
--- a/.claude/commands/ci-local.sh
+++ b/.claude/commands/ci-local.sh
@@ -71,6 +71,32 @@ setup_ci_env() {
   fi
 }
 
+
+verify_deployment() {
+  # Mirror "Verify dotfiles deployment" step in .github/workflows/ci.yml.
+  local file
+  local files=(.bashrc .bash_profile .zshenv .zshrc .gitconfig .tmux.conf)
+
+  for file in "${files[@]}"; do
+    if [ -L "$HOME/$file" ]; then
+      log_success "$file は正常にデプロイされました"
+    else
+      log_error "$file のデプロイに失敗しました"
+      return 1
+    fi
+  done
+
+  local link_count
+  link_count=$(find "$HOME/.config" -maxdepth 1 -type l | wc -l)
+  log_info "~/.config/ 内のシンボリックリンク数: $link_count"
+
+  if [ "$link_count" -ge 46 ]; then
+    log_success "期待されるファイル数（46個以上）が配置されました"
+  else
+    log_warning "配置されたファイル数が期待値より少ない（期待: 46個以上、実際: $link_count個）"
+  fi
+}
+
 check_mise_installation() {
   if ! command -v mise &>/dev/null; then
     log_error "mise が見つかりません"
@@ -130,8 +156,16 @@ run_ci_checks() {
       log_error "Home Manager deploy - FAILED"
       return 1
     fi
+
+    log_info "実行中: Verify dotfiles deployment"
+    if verify_deployment; then
+      log_success "dotfiles deployment verify - PASSED"
+    else
+      log_error "dotfiles deployment verify - FAILED"
+      return 1
+    fi
   else
-    log_warning "nix が見つからないため、ci:deploy はスキップします"
+    log_warning "nix が見つからないため、ci:deploy と deployment verify はスキップします"
   fi
 
   # CI workflow parity: Run all CI checks via aggregate task.


### PR DESCRIPTION
### Motivation
- `ci-local` が GitHub Actions のワークフローと「完全同等」と表現していたが、実際は固定のサブセットタスクしか実行しておらずローカル検証と CI にズレが生じていたため。
- ローカル実行で可能な限りワークフローのチェック内容と整合させ、開発者がローカルで本番に近い検証を行えるようにするため。

### Description
- `usage` のヘルプ文を修正して「完全同等」から「workflow のチェック内容を実行」に表現を明確化した（`./.claude/commands/ci-local.sh`）。
- 新関数 `setup_ci_env` を追加し、未設定時は `MISE_CONFIG_FILE` を `mise/config.ci.toml` に自動設定するようにした。`
- `run_ci_checks` を変更して、従来のハードコードされたタスクリストを廃止し、ワークフロー側と一致させるために `mise run ci`（集約タスク）を実行するようにした。
- 可能な限りワークフローの `deploy` ステップを再現するため、`nix` が存在するローカル環境では事前に `mise run ci:deploy` をベストエフォートで実行する処理を追加した。

### Testing
- スクリプト構文チェックとして `bash -n .claude/commands/ci-local.sh` を実行し、エラーなしで通過しました（成功）。
- ヘルプ出力検証として `./.claude/commands/ci-local.sh --help` を実行して想定するヘルプが出力されることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d81de5054832f903569fceed5fa4a)