### PR TITLE
fix(mise): make lint:shell resilient when zsh is unavailable

### DIFF
--- a/mise/tasks/lint.toml
+++ b/mise/tasks/lint.toml
@@ -80,8 +80,10 @@ if [ -n "${SH_FILES:-}" ]; then
     shellcheck ${shfmt_files}
   fi
 
-  if [ -n "${zsh_files}" ]; then
+  if [ -n "${zsh_files}" ] && command -v zsh >/dev/null 2>&1; then
     zsh -n ${zsh_files}
+  elif [ -n "${zsh_files}" ]; then
+    echo "⚠️ zsh not found; skipping zsh syntax check for:${zsh_files}"
   fi
 else
   # scripts/ (some files have no extension)
@@ -97,8 +99,12 @@ else
   fd -e sh ${TASK_EXCLUDES} -X shellcheck
 
   # zsh syntax check (.zsh + zsh/bin/*)
-  fd --hidden -e zsh -X zsh -n
-  fd -t f -H -p '^zsh/bin/' -X zsh -n
+  if command -v zsh >/dev/null 2>&1; then
+    fd --hidden -e zsh -X zsh -n
+    fd -t f -H -p '^zsh/bin/' -X zsh -n
+  else
+    echo "⚠️ zsh not found; skipping zsh syntax checks"
+  fi
 fi
 """
 


### PR DESCRIPTION
## Summary
- guard zsh syntax checks in `mise/tasks/lint.toml` behind `command -v zsh`
- skip zsh checks with a warning when zsh is not installed (e.g. GitHub Actions Ubuntu)
- keep existing behavior unchanged when zsh exists

## Verification
- `mise run lint:shell`
- `SKIP_NIX_VALIDATE=1 mise run ci`

## Context
- fixes CI failure: `[fd error]: Command not found: zsh` in `lint:shell`
