### PR TITLE
nix: fix Raspberry Pi env detection (NUL byte devicetree model)

### DIFF
--- a/nix/env-detect.nix
+++ b/nix/env-detect.nix
@@ -28,8 +28,12 @@
       #   which `builtins.readFile` cannot represent as a Nix string.
       # - `/proc/cpuinfo` is safe text on Linux, but doesn't exist on e.g. Darwin.
       isRaspberryPiModel =
-        pkgs.stdenv.isLinux && builtins.pathExists "/proc/cpuinfo" &&
-        builtins.match ".*Raspberry Pi.*" (builtins.readFile "/proc/cpuinfo") != null;
+        let
+          cpuinfoPath = "/proc/cpuinfo";
+          cpuinfo = builtins.tryEval (builtins.readFile cpuinfoPath);
+        in
+        pkgs.stdenv.isLinux && cpuinfo.success &&
+        builtins.match ".*Raspberry Pi.*" cpuinfo.value != null;
 
       # CI detection: $CI or $GITHUB_ACTIONS environment variables
       isCI = hasEnvValue "CI" "true" || hasEnvValue "GITHUB_ACTIONS" "true";


### PR DESCRIPTION
## 概要

Home Manager の flake 評価時に `builtins.readFile /sys/firmware/devicetree/base/model` が NUL byte を含むため失敗していたので、Pi 判定を `/proc/cpuinfo` ベースに変更して回避します。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [x] 動作確認完了（`nix run home-manager -- switch --flake . --impure -b backup`）
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
