### PR TITLE
bash: add cl/co/cz aliases for claude/codex

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -100,6 +100,11 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
+# AI CLIs
+alias cl='claude --dangerously-skip-permissions'
+alias co='codex --yolo'
+alias cz='ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic ANTHROPIC_AUTH_TOKEN="$ZAI_API_KEY" claude --dangerously-skip-permissions'
+
 # Starship prompt (if available)
 if command -v starship >/dev/null 2>&1; then
   eval "$(starship init bash)"


### PR DESCRIPTION
## 概要

bash の `.bashrc` に AI CLI 用の alias を追加します。

- `cl` → `claude --dangerously-skip-permissions`
- `co` → `codex --yolo`
- `cz` → Z.AI の Anthropic 互換エンドポイントに向けて `ZAI_API_KEY` を `ANTHROPIC_AUTH_TOKEN` に渡して起動

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
