### PR TITLE
home-manager: install starship

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -11,6 +11,15 @@
     rsync  # Required for copy-tree deployment
   ];
 
+  # Starship prompt
+  programs.starship = {
+    enable = true;
+    enableBashIntegration = true;
+    enableZshIntegration = true;
+  };
+
+  # NOTE: starship.toml is already at ~/.config/starship.toml because this repo is ~/.config
+
   # Let Home Manager manage itself
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
## 概要

Home Manager 経由で starship をインストールします（bash/zsh の integration も有効化）。

※ `~/.config/starship.toml` は、このリポジトリ自体が `~/.config` にあるため、別途 home-manager で配布しません。

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [x] 動作確認完了（`nix run home-manager -- switch --flake . --impure -b backup`）
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
