### PR TITLE
fix(ssh): SSH設定の近代化と不要ファイル整理

### DIFF
--- a/ssh/config.d/common/00-global.sshconfig
+++ b/ssh/config.d/common/00-global.sshconfig
@@ -19,11 +19,10 @@ Host *
 
   # Default authentication settings
   IdentityFile ~/.ssh/id_rsa
-  PasswordAuthentication yes
+  PasswordAuthentication no
   PubkeyAuthentication yes
 
   # Default connection settings
-  Protocol 2
   ForwardAgent no
   ForwardX11 no
 


### PR DESCRIPTION
## Summary
- `Protocol 2` ディレクティブを削除（現在のOpenSSHでは廃止済み）
- `PasswordAuthentication yes` → `no` に変更（公開鍵認証のみに限定）
- `~/.ssh/` から不要ファイル5件を削除（config.old, config.backup, config.backup.20250615_035011, known_hosts.old, hosts）
- `~/.ssh/ssh_config.d/` のパーミッションを700に、`infosys.sshconfig` を600に修正

## 変更しない項目
- `HostKeyAlgorithms +ssh-rsa` / `PubkeyAcceptedKeyTypes +ssh-rsa` はレガシーサーバー互換のため維持

## Test plan
- [x] `ssh -G github.com` で構文チェック通過
- [ ] `ssh -T git@github.com` で接続テスト